### PR TITLE
Bug fix in DeleteHandler and friendlier error messages for invalid requests

### DIFF
--- a/workgroup/src/main/java/software/amazon/athena/workgroup/CreateHandler.java
+++ b/workgroup/src/main/java/software/amazon/athena/workgroup/CreateHandler.java
@@ -55,7 +55,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
     } catch (InternalServerException e) {
       throw new CfnGeneralServiceException("createWorkGroup", e);
     } catch (InvalidRequestException e) {
-      throw new CfnInvalidRequestException(createWorkGroupRequest.toString(), e);
+      throw new CfnInvalidRequestException(e.getMessage(), e);
     }
   }
 

--- a/workgroup/src/main/java/software/amazon/athena/workgroup/DeleteHandler.java
+++ b/workgroup/src/main/java/software/amazon/athena/workgroup/DeleteHandler.java
@@ -41,7 +41,7 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
 
   private void deleteWorkGroup(final ResourceModel model) {
     final DeleteWorkGroupRequest deleteWorkGroupRequest = DeleteWorkGroupRequest.builder()
-      .workGroup(model.getPrimaryIdentifier().toString())
+      .workGroup(model.getName())
       .recursiveDeleteOption(model.getRecursiveDeleteOption())
       .build();
     try {
@@ -50,9 +50,9 @@ public class DeleteHandler extends BaseHandler<CallbackContext> {
       throw new CfnGeneralServiceException("deleteWorkGroup", e);
     } catch (InvalidRequestException e) {
       if (e.athenaErrorCode().equalsIgnoreCase(WORKGROUP_NOT_EMPTY_ERROR_MSG)) {
-        logger.log(String.format("Workgroup [ %s ] not empty", model.getPrimaryIdentifier().toString()));
+        logger.log(String.format("Workgroup [ %s ] not empty", model.getName()));
       }
-      throw new CfnInvalidRequestException(deleteWorkGroupRequest.toString(), e);
+      throw new CfnInvalidRequestException(e.getMessage(), e);
     }
   }
 }

--- a/workgroup/src/main/java/software/amazon/athena/workgroup/ListHandler.java
+++ b/workgroup/src/main/java/software/amazon/athena/workgroup/ListHandler.java
@@ -60,7 +60,7 @@ public class ListHandler extends BaseHandler<CallbackContext> {
     } catch (InternalServerException e) {
       throw new CfnGeneralServiceException("listWorkGroupsRequest", e);
     } catch (InvalidRequestException e) {
-      throw new CfnInvalidRequestException(listWorkGroupsRequest.toString(), e);
+      throw new CfnInvalidRequestException(e.getMessage(), e);
     }
   }
 }

--- a/workgroup/src/main/java/software/amazon/athena/workgroup/ReadHandler.java
+++ b/workgroup/src/main/java/software/amazon/athena/workgroup/ReadHandler.java
@@ -50,7 +50,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
     } catch (InternalServerException e) {
       throw new CfnGeneralServiceException("getWorkGroup", e);
     } catch (InvalidRequestException e) {
-      throw new CfnInvalidRequestException(getWorkGroupRequest.toString(), e);
+      throw new CfnInvalidRequestException(e.getMessage(), e);
     }
   }
 }

--- a/workgroup/src/main/java/software/amazon/athena/workgroup/Translator.java
+++ b/workgroup/src/main/java/software/amazon/athena/workgroup/Translator.java
@@ -1,6 +1,5 @@
 package software.amazon.athena.workgroup;
 
-import com.google.common.annotations.VisibleForTesting;
 import software.amazon.awssdk.services.athena.model.ResultConfigurationUpdates;
 import software.amazon.awssdk.services.athena.model.WorkGroupConfiguration;
 import software.amazon.awssdk.services.athena.model.ResultConfiguration;

--- a/workgroup/src/main/java/software/amazon/athena/workgroup/UpdateHandler.java
+++ b/workgroup/src/main/java/software/amazon/athena/workgroup/UpdateHandler.java
@@ -57,7 +57,7 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
     } catch (InternalServerException e) {
       throw new CfnGeneralServiceException("updateWorkGroup", e);
     } catch (InvalidRequestException e) {
-      throw new CfnInvalidRequestException(updateWorkGroupRequest.toString(), e);
+      throw new CfnInvalidRequestException(e.getMessage(), e);
     }
   }
 


### PR DESCRIPTION
**Description of changes:**

Bug fix in DeleteHandler (would fail to delete WorkGroups previously) and friendlier error messages for invalid requests. Also remove an unused import. 

For the error messages, they are much easier to debug for customers now. Before, an invalid request would look like this:

`Invalid request provided: DeleteWorkGroupRequest(WorkGroup{"/properties/Name":"MyWorkGroup"})`

This doesn't inform the customer what the issue is. Here is an example improved message:

`Invalid request provided: WorkGroup MyWorkGroup is not found. (Service: Athena, Status Code: 400, Request ID: 89a1cbbc-5824-4be6-9aa0-6026a9536b7e)`

This is the message returned from the public Athena API, so they are already worded in a friendly and informative way for customers.

**Testing:**

Unit and integration tests passing.

--------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
