### PR TITLE
NamedQuery: add dummy update handler and support for specifying WorkGroup

### DIFF
--- a/namedquery/aws-athena-namedquery.json
+++ b/namedquery/aws-athena-namedquery.json
@@ -27,6 +27,12 @@
             "minLength": 1,
             "maxLength": 262144
         },
+        "WorkGroup": {
+            "description": "The name of the workgroup that contains the named query.",
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 128
+        },
         "NamedQueryId": {
             "description": "The unique ID of the query.",
             "type": "string"
@@ -56,6 +62,9 @@
             "permissions": [
                 "athena:DeleteNamedQuery"
             ]
+        },
+        "update": {
+            "permissions": []
         }
     },
     "readOnlyProperties": [
@@ -65,7 +74,8 @@
         "/properties/Name",
         "/properties/Database",
         "/properties/Description",
-        "/properties/QueryString"
+        "/properties/QueryString",
+        "/properties/WorkGroup"
     ],
     "primaryIdentifier": [
         "/properties/NamedQueryId"

--- a/namedquery/pom.xml
+++ b/namedquery/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>

--- a/namedquery/src/main/java/software/amazon/athena/namedquery/CreateHandler.java
+++ b/namedquery/src/main/java/software/amazon/athena/namedquery/CreateHandler.java
@@ -60,6 +60,7 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
                 .description(model.getDescription())
                 .name(model.getName())
                 .queryString(model.getQueryString())
+                .workGroup(model.getWorkGroup())
                 .build();
         try {
             return clientProxy.injectCredentialsAndInvokeV2(

--- a/namedquery/src/main/java/software/amazon/athena/namedquery/ReadHandler.java
+++ b/namedquery/src/main/java/software/amazon/athena/namedquery/ReadHandler.java
@@ -45,6 +45,7 @@ public class ReadHandler extends BaseHandler<CallbackContext> {
                     .database(namedQuery.database())
                     .description(namedQuery.description())
                     .queryString(namedQuery.queryString())
+                    .workGroup(namedQuery.workGroup())
                     .build();
         } catch (InternalServerException e) {
             throw new CfnGeneralServiceException("getNamedQuery", e);

--- a/namedquery/src/main/java/software/amazon/athena/namedquery/UpdateHandler.java
+++ b/namedquery/src/main/java/software/amazon/athena/namedquery/UpdateHandler.java
@@ -16,9 +16,13 @@ public class UpdateHandler extends BaseHandler<CallbackContext> {
         final CallbackContext callbackContext,
         final Logger logger) {
 
+        logger.log(String.format("%s [%s] calling dummy update handler",
+            ResourceModel.TYPE_NAME, request.getDesiredResourceState().getNamedQueryId()));
+
         return ProgressEvent.<ResourceModel, CallbackContext>builder()
-            .errorCode(HandlerErrorCode.NotUpdatable)
-            .status(OperationStatus.FAILED)
+            .resourceModel(request.getDesiredResourceState())
+            .status(OperationStatus.SUCCESS)
             .build();
+
     }
 }

--- a/namedquery/src/test/java/software/amazon/athena/namedquery/CreateHandlerTest.java
+++ b/namedquery/src/test/java/software/amazon/athena/namedquery/CreateHandlerTest.java
@@ -2,16 +2,20 @@ package software.amazon.athena.namedquery;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static software.amazon.athena.namedquery.CreateHandler.MAX_NAME_LENGTH;
 
+import software.amazon.awssdk.services.athena.model.CreateNamedQueryRequest;
 import software.amazon.awssdk.services.athena.model.CreateNamedQueryResponse;
 import software.amazon.awssdk.services.athena.model.InternalServerException;
 import software.amazon.awssdk.services.athena.model.InvalidRequestException;
@@ -100,6 +104,53 @@ class CreateHandlerTest {
         );
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
+    void testSuccessStateWithWorkGroup() {
+        // Prepare inputs
+        final String name = "name";
+        final String database = "database";
+        final String description = "description";
+        final String queryString = "queryString";
+        final String workGroup = "myWorkGroup";
+        final ResourceModel resourceModel = ResourceModel.builder()
+                .name(name)
+                .database(database)
+                .description(description)
+                .queryString(queryString)
+                .workGroup(workGroup)
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(resourceModel)
+                .build();
+        final String namedQueryId = "namedQueryId";
+
+        // Mock
+        final ArgumentCaptor<CreateNamedQueryRequest> requestCaptor = ArgumentCaptor
+                .forClass(CreateNamedQueryRequest.class);
+        doReturn(CreateNamedQueryResponse.builder().namedQueryId(namedQueryId).build())
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        // Call
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = new CreateHandler().handleRequest(proxy, request, null, logger);
+        verify(proxy).injectCredentialsAndInvokeV2(requestCaptor.capture(), any());
+        final CreateNamedQueryRequest argument = requestCaptor.getValue();
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel().getNamedQueryId()).isEqualTo(namedQueryId);
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+        assertEquals(name, argument.name());
+        assertEquals(database, argument.database());
+        assertEquals(description, argument.description());
+        assertEquals(queryString, argument.queryString());
+        assertEquals(workGroup, argument.workGroup());
     }
 
     @Test

--- a/namedquery/src/test/java/software/amazon/athena/namedquery/ReadHandlerTest.java
+++ b/namedquery/src/test/java/software/amazon/athena/namedquery/ReadHandlerTest.java
@@ -72,6 +72,48 @@ class ReadHandlerTest {
     }
 
     @Test
+    void testSuccessStateWithWorkGroup() {
+        // Prepare inputs
+        final ResourceModel resourceModel = ResourceModel.builder()
+                .namedQueryId("namedQueryId")
+                .build();
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(resourceModel)
+                .build();
+        final NamedQuery namedQuery = NamedQuery.builder()
+                .database("database")
+                .description("description")
+                .name("name")
+                .queryString("querystring")
+                .workGroup("myWorkGroup")
+                .build();
+
+        // Mock
+        doReturn(
+                GetNamedQueryResponse.builder()
+                        .namedQuery(namedQuery)
+                        .build())
+                .when(proxy)
+                .injectCredentialsAndInvokeV2(any(), any());
+
+        // Call
+        final ProgressEvent<ResourceModel, CallbackContext> response
+                = new ReadHandler().handleRequest(proxy, request, null, logger);
+
+        // Assert
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel().getDatabase()).isEqualTo(namedQuery.database());
+        assertThat(response.getResourceModel().getDescription()).isEqualTo(namedQuery.description());
+        assertThat(response.getResourceModel().getName()).isEqualTo(namedQuery.name());
+        assertThat(response.getResourceModel().getQueryString()).isEqualTo(namedQuery.queryString());
+        assertThat(response.getResourceModel().getWorkGroup()).isEqualTo(namedQuery.workGroup());
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+    }
+
+    @Test
     void testInternalServerException() {
         // Prepare inputs
         final ResourceModel resourceModel = ResourceModel.builder()

--- a/namedquery/src/test/java/software/amazon/athena/namedquery/UpdateHandlerTest.java
+++ b/namedquery/src/test/java/software/amazon/athena/namedquery/UpdateHandlerTest.java
@@ -32,12 +32,12 @@ class UpdateHandlerTest {
             new UpdateHandler().handleRequest(proxy, request, null, logger);
 
         assertThat(response).isNotNull();
-        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackContext()).isNull();
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
-        assertThat(response.getResourceModel()).isNull();
+        assertThat(response.getResourceModel()).isEqualTo(ResourceModel.builder().build());
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotUpdatable);
+        assertThat(response.getErrorCode()).isNull();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

NamedQuery: add dummy update handler and support for specifying WorkGroup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
