### PR TITLE
Propagating Stack-level tags to Athena resources -II

### DIFF
--- a/datacatalog/src/main/java/software/amazon/athena/datacatalog/Translator.java
+++ b/datacatalog/src/main/java/software/amazon/athena/datacatalog/Translator.java
@@ -49,6 +49,10 @@ class Translator {
 
   static List<software.amazon.awssdk.services.athena.model.Tag> convertToAthenaSdkTags(
           final Collection<Tag> resourceTags, final Map<String, String> stackLevelTags) {
+
+    if (CollectionUtils.isEmpty(resourceTags) && MapUtils.isEmpty(stackLevelTags)) {
+      return null;
+    }
     Map<String, String> consolidatedTags = Maps.newHashMap();
     if (MapUtils.isNotEmpty(stackLevelTags)) consolidatedTags.putAll(stackLevelTags);
 

--- a/datacatalog/src/main/java/software/amazon/athena/datacatalog/UpdateHandler.java
+++ b/datacatalog/src/main/java/software/amazon/athena/datacatalog/UpdateHandler.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toList;
 import static software.amazon.athena.datacatalog.HandlerUtils.getDatacatalogArn;
 import static software.amazon.athena.datacatalog.HandlerUtils.handleExceptions;
 
+import com.amazonaws.util.CollectionUtils;
 import com.google.common.collect.Sets;
 import java.util.HashSet;
 import java.util.Set;
@@ -110,6 +111,7 @@ public class UpdateHandler extends BaseHandlerAthena {
     private Set<Tag> getAthenaSdkTags(ResourceModel resourceModel, Map<String, String> stackTags) {
         List<software.amazon.athena.datacatalog.Tag> resourceTags = resourceModel == null ? Collections.emptyList() :
                 resourceModel.getTags();
-        return new HashSet<>(Translator.convertToAthenaSdkTags(resourceTags, stackTags));
+        List<Tag> athenaTags = Translator.convertToAthenaSdkTags(resourceTags, stackTags);
+        return CollectionUtils.isNullOrEmpty(athenaTags) ? Collections.emptySet(): new HashSet<>(athenaTags);
     }
 }

--- a/datacatalog/src/test/java/software/amazon/athena/datacatalog/TranslatorTest.java
+++ b/datacatalog/src/test/java/software/amazon/athena/datacatalog/TranslatorTest.java
@@ -1,0 +1,43 @@
+package software.amazon.athena.datacatalog;
+
+import junit.framework.Assert;
+import org.junit.jupiter.api.Test;
+
+import software.amazon.awssdk.services.athena.model.Tag;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class TranslatorTest {
+
+    @Test
+    public void convertToAthenaSdkTags_tests() {
+
+        ResourceModel resourceModel = BaseHandlerTest.buildTestResourceModel();
+        Map<String, String> stackTags = new HashMap<>();
+
+        //Case 0: Empty test.
+        List<Tag> tags = Translator.convertToAthenaSdkTags(Collections.emptyList(), stackTags);
+        Assert.assertNull(tags);
+
+        //Case 1: No stack tags
+        tags = Translator.convertToAthenaSdkTags(resourceModel.getTags(), stackTags);
+        Assert.assertEquals(1, tags.size());
+
+        //Case 2: Valid stack tags
+        stackTags.put("StackKey", "StackValue");
+        tags = Translator.convertToAthenaSdkTags(resourceModel.getTags(), stackTags);
+        Assert.assertEquals(2, tags.size());
+
+        //Case 3: Stack tag overridden by resource tag.
+        stackTags.put("testKey1", "StackTagValue");
+        tags = Translator.convertToAthenaSdkTags(resourceModel.getTags(), stackTags);
+        Assert.assertEquals(2, tags.size());
+        Optional<String> value = tags.stream().filter(tag -> "testKey1".equals(tag.key())).map(Tag::value).findFirst();
+        Assert.assertTrue(value.isPresent());
+        Assert.assertTrue("someValue1".equals(value.get()));
+    }
+}

--- a/workgroup/src/main/java/software/amazon/athena/workgroup/CreateHandler.java
+++ b/workgroup/src/main/java/software/amazon/athena/workgroup/CreateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.athena.workgroup;
 
+import org.apache.commons.collections.CollectionUtils;
 import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.athena.model.AthenaException;
 import software.amazon.awssdk.services.athena.model.CreateWorkGroupRequest;
@@ -9,6 +10,7 @@ import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.List;
 import java.util.Map;
 
 import static software.amazon.athena.workgroup.HandlerUtils.translateAthenaException;
@@ -46,11 +48,13 @@ public class CreateHandler extends BaseHandler<CallbackContext> {
   private CreateWorkGroupResponse createWorkgroup() {
     final ResourceModel model = request.getDesiredResourceState();
     final Map<String, String> stackTags = request.getDesiredResourceTags();
+    List<software.amazon.awssdk.services.athena.model.Tag> tags =
+            translator.createConsolidatedSdkTagsFromCfnTags(model.getTags(), stackTags);
 
     final CreateWorkGroupRequest createWorkGroupRequest = CreateWorkGroupRequest.builder()
       .name(model.getName())
       .description(model.getDescription())
-      .tags(translator.createConsolidatedSdkTagsFromCfnTags(model.getTags(), stackTags))
+      .tags(CollectionUtils.isEmpty(tags) ? null: tags)
       .configuration(model.getWorkGroupConfiguration() != null ?
         translator.createSdkWorkgroupConfigurationFromCfnConfiguration(model.getWorkGroupConfiguration()) : null)
       .build();


### PR DESCRIPTION
*Issue #, if available:*
[cloudformation-coverage-roadmap/issues](https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1417) 
Fixes an issue found in #47, where tags should be set to null instead of an empty list. 

*Description of changes:*

This change propagates cloud formation stack-level tags to Athena DataCatalog and Workgroup. 
Note: NamedQuery, PreparedStatement do not support tags. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
