### PR TITLE
Initial commit for FEDERATED DataCatalog changes

### DIFF
--- a/datacatalog/.rpdk-config
+++ b/datacatalog/.rpdk-config
@@ -1,8 +1,8 @@
 {
     "artifact_type": "RESOURCE",
-    "typeName": "AWS::Athena::DataCatalog",
+    "typeName": "Example::Jeff::JeffCatalog",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java11",
     "entrypoint": "software.amazon.athena.datacatalog.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.athena.datacatalog.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/datacatalog/example-jeff-jeffcatalog.json
+++ b/datacatalog/example-jeff-jeffcatalog.json
@@ -1,5 +1,5 @@
 {
-    "typeName": "AWS::Athena::DataCatalog",
+    "typeName": "Example::Jeff::JeffCatalog",
     "description": "Resource schema for AWS::Athena::DataCatalog",
     "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-athena.git",
     "definitions": {
@@ -65,7 +65,8 @@
             "enum": [
                 "LAMBDA",
                 "GLUE",
-                "HIVE"
+                "HIVE",
+                "FEDERATED"
             ]
         }
     },
@@ -77,7 +78,39 @@
         "create": {
             "permissions": [
                 "athena:CreateDataCatalog",
-                "athena:TagResource"
+                "athena:TagResource",
+                "s3:ListBucket",
+                "glue:TagResource",
+                "glue:CreateConnection",
+                "glue:DeleteConnection",
+                "glue:UpdateConnection",
+                "serverlessrepo:CreateCloudFormationTemplate",
+                "serverlessrepo:GetCloudFormationTemplate",
+                "cloudformation:CreateStack",
+                "cloudformation:DeleteStack",
+                "cloudformation:DescribeStacks",
+                "cloudformation:CreateChangeSet",
+                "iam:AttachRolePolicy",
+                "iam:DetachRolePolicy",
+                "iam:DeleteRolePolicy",
+                "iam:PutRolePolicy",
+                "iam:CreateRole",
+                "iam:TagRole",
+                "iam:DeleteRole",
+                "iam:GetRole",
+                "iam:GetRolePolicy",
+                "iam:PassRole",
+                "lambda:DeleteFunction",
+                "lambda:CreateFunction",
+                "lambda:TagResource",
+                "lambda:GetFunction",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeVpcs",
+                "secretsmanager:ListSecrets",
+                "glue:GetConnection",
+                "ecr:BatchGetImage",
+                "ecr:GetDownloadUrlForLayer"
             ]
         },
         "read": {

--- a/datacatalog/pom.xml
+++ b/datacatalog/pom.xml
@@ -6,14 +6,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>software.amazon.athena.datacatalog</groupId>
-    <artifactId>aws-athena-datacatalog-handler</artifactId>
-    <name>aws-athena-datacatalog-handler</name>
+    <artifactId>example-jeff-jeffcatalog-handler</artifactId>
+    <name>example-jeff-jeffcatalog-handler</name>
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+<!--        <maven.compiler.source>1.8</maven.compiler.source>-->
+<!--        <maven.compiler.target>1.8</maven.compiler.target>-->
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -23,7 +24,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>athena</artifactId>
-            <version>2.19.18</version>
+            <version>2.29.47</version>
         </dependency>
         <!-- https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/ -->
         <dependency>
@@ -201,7 +202,7 @@
             <resource>
                 <directory>${project.basedir}</directory>
                 <includes>
-                    <include>aws-athena-datacatalog.json</include>
+                    <include>example-jeff-jeffcatalog.json</include>
                 </includes>
             </resource>
         </resources>

--- a/datacatalog/resource-role.yaml
+++ b/datacatalog/resource-role.yaml
@@ -21,7 +21,7 @@ Resources:
                   Ref: AWS::AccountId
               StringLike:
                 aws:SourceArn:
-                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/AWS-Athena-DataCatalog/*
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Example-Jeff-JeffCatalog/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy
@@ -38,6 +38,38 @@ Resources:
                 - "athena:TagResource"
                 - "athena:UntagResource"
                 - "athena:UpdateDataCatalog"
+                - "cloudformation:CreateChangeSet"
+                - "cloudformation:CreateStack"
+                - "cloudformation:DeleteStack"
+                - "cloudformation:DescribeStacks"
+                - "ec2:DescribeSecurityGroups"
+                - "ec2:DescribeSubnets"
+                - "ec2:DescribeVpcs"
+                - "ecr:BatchGetImage"
+                - "ecr:GetDownloadUrlForLayer"
+                - "glue:CreateConnection"
+                - "glue:DeleteConnection"
+                - "glue:GetConnection"
+                - "glue:TagResource"
+                - "glue:UpdateConnection"
+                - "iam:AttachRolePolicy"
+                - "iam:CreateRole"
+                - "iam:DeleteRole"
+                - "iam:DeleteRolePolicy"
+                - "iam:DetachRolePolicy"
+                - "iam:GetRole"
+                - "iam:GetRolePolicy"
+                - "iam:PassRole"
+                - "iam:PutRolePolicy"
+                - "iam:TagRole"
+                - "lambda:CreateFunction"
+                - "lambda:DeleteFunction"
+                - "lambda:GetFunction"
+                - "lambda:TagResource"
+                - "s3:ListBucket"
+                - "secretsmanager:ListSecrets"
+                - "serverlessrepo:CreateCloudFormationTemplate"
+                - "serverlessrepo:GetCloudFormationTemplate"
                 Resource: "*"
 Outputs:
   ExecutionRoleArn:

--- a/datacatalog/src/main/java/software/amazon/athena/datacatalog/BaseHandlerAthena.java
+++ b/datacatalog/src/main/java/software/amazon/athena/datacatalog/BaseHandlerAthena.java
@@ -8,6 +8,8 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.net.URI;
+
 public abstract class BaseHandlerAthena extends BaseHandler<CallbackContext> {
 
   @Override
@@ -33,7 +35,8 @@ public abstract class BaseHandlerAthena extends BaseHandler<CallbackContext> {
 
   public AthenaClient getClient() {
     return AthenaClient.builder()
-        .httpClient(LambdaWrapper.HTTP_CLIENT)
-        .build();
+            .endpointOverride(URI.create("https://athena-webservice-preprod.eu-west-1.amazonaws.com"))
+            .httpClient(LambdaWrapper.HTTP_CLIENT)
+            .build();
   }
 }

--- a/datacatalog/src/main/java/software/amazon/athena/datacatalog/Configuration.java
+++ b/datacatalog/src/main/java/software/amazon/athena/datacatalog/Configuration.java
@@ -3,6 +3,6 @@ package software.amazon.athena.datacatalog;
 class Configuration extends BaseConfiguration {
 
     public Configuration() {
-        super("aws-athena-datacatalog.json");
+        super("example-jeff-jeffcatalog.json");
     }
 }

--- a/datacatalog/src/main/java/software/amazon/athena/datacatalog/CreateHandler.java
+++ b/datacatalog/src/main/java/software/amazon/athena/datacatalog/CreateHandler.java
@@ -1,5 +1,6 @@
 package software.amazon.athena.datacatalog;
 
+import static software.amazon.athena.datacatalog.HandlerUtils.getDataCatalog;
 import static software.amazon.athena.datacatalog.HandlerUtils.handleExceptions;
 
 import software.amazon.awssdk.services.athena.AthenaClient;
@@ -7,8 +8,12 @@ import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.athena.model.AthenaException;
 import software.amazon.awssdk.services.athena.model.CreateDataCatalogRequest;
 import software.amazon.awssdk.services.athena.model.CreateDataCatalogResponse;
+import software.amazon.awssdk.services.athena.model.DataCatalog;
+import software.amazon.awssdk.services.athena.model.DataCatalogStatus;
+import software.amazon.awssdk.services.athena.model.DataCatalogType;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
@@ -34,7 +39,25 @@ public class CreateHandler extends BaseHandlerAthena {
                                                                  request.getDesiredResourceTags(),
                                                                  request.getSystemTags()))
             .makeServiceCall(this::createDataCatalog)
-            .success();
+            .stabilize((createRequest, createResponse, client, model, context) -> {
+                if (model.getType().equals(DataCatalogType.FEDERATED.name())) {
+                    return !getDataCatalog(client, model).status().equals(DataCatalogStatus.CREATE_IN_PROGRESS);
+                }
+                return true;
+            })
+            .done((createRequest, createResponse, client, model, context) -> {
+                OperationStatus operationStatus = OperationStatus.SUCCESS;
+                ProgressEvent.ProgressEventBuilder<ResourceModel, CallbackContext> progressEventBuilder = ProgressEvent.<ResourceModel, CallbackContext>builder()
+                        .resourceModel(model);
+                if (model.getType().equals(DataCatalogType.FEDERATED.name())) {
+                    DataCatalog dataCatalog = getDataCatalog(client, model);
+                    if (!dataCatalog.status().equals(DataCatalogStatus.CREATE_COMPLETE)) {
+                        operationStatus = OperationStatus.FAILED;
+                        progressEventBuilder.message(dataCatalog.error());
+                    }
+                }
+                return progressEventBuilder.status(operationStatus).build();
+            });
     }
 
     private CreateDataCatalogResponse createDataCatalog(

--- a/datacatalog/src/main/java/software/amazon/athena/datacatalog/HandlerUtils.java
+++ b/datacatalog/src/main/java/software/amazon/athena/datacatalog/HandlerUtils.java
@@ -1,12 +1,19 @@
 package software.amazon.athena.datacatalog;
 
+import com.amazonaws.auth.policy.Resource;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+
+import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.athena.model.AthenaException;
+import software.amazon.awssdk.services.athena.model.DataCatalog;
+import software.amazon.awssdk.services.athena.model.GetDataCatalogRequest;
+import software.amazon.awssdk.services.athena.model.GetDataCatalogResponse;
 import software.amazon.awssdk.services.athena.model.InvalidRequestException;
 import software.amazon.awssdk.services.athena.model.ResourceNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 class HandlerUtils {
@@ -16,7 +23,7 @@ class HandlerUtils {
    */
   private static final String DATACATALOG_ARN_FORMAT = "arn:%s:athena:%s:%s:datacatalog/%s";
 
-  public static final String RESOURCE_TYPE = "AWS::Athena::DataCatalog";
+  public static final String RESOURCE_TYPE = "Example::Jeff::JeffCatalog";
 
   static String getDatacatalogArn(ResourceHandlerRequest<ResourceModel> request, String catalogName) {
     return String.format(DATACATALOG_ARN_FORMAT,
@@ -37,5 +44,12 @@ class HandlerUtils {
     } else {
       return e;
     }
+  }
+
+  static DataCatalog getDataCatalog(ProxyClient<AthenaClient> client, ResourceModel model) {
+    GetDataCatalogRequest getDataCatalogRequest = Translator.getDataCatalogRequest(model);
+    GetDataCatalogResponse getDataCatalogResponse = client.injectCredentialsAndInvokeV2(
+            getDataCatalogRequest, client.client()::getDataCatalog);
+    return getDataCatalogResponse.dataCatalog();
   }
 }

--- a/datacatalog/src/test/java/software/amazon/athena/datacatalog/BaseHandlerTest.java
+++ b/datacatalog/src/test/java/software/amazon/athena/datacatalog/BaseHandlerTest.java
@@ -112,6 +112,17 @@ public abstract class BaseHandlerTest {
         .build();
   }
 
+  protected static ResourceModel buildTestResourceModelFederated() {
+    return ResourceModel.builder()
+            .name("TestCatalog")
+            .description("full description")
+            .type("FEDERATED")
+            .tags(Lists.list(
+                    Tag.builder().key("testKey1").value("someValue1").build()))
+            .parameters(ImmutableMap.of("connection-type", "DYNAMODB", "connection-properties", "{\"spill_bucket\":\"test_spill\"}"))
+            .build();
+  }
+
   protected static ResourceModel buildTestResourceModelWithNullTags() {
     return ResourceModel.builder()
         .name("TestCatalog")

--- a/datacatalog/src/test/java/software/amazon/athena/datacatalog/DeleteHandlerTest.java
+++ b/datacatalog/src/test/java/software/amazon/athena/datacatalog/DeleteHandlerTest.java
@@ -1,7 +1,11 @@
 package software.amazon.athena.datacatalog;
 
+import software.amazon.awssdk.services.athena.model.DataCatalog;
+import software.amazon.awssdk.services.athena.model.DataCatalogStatus;
 import software.amazon.awssdk.services.athena.model.DeleteDataCatalogRequest;
 import software.amazon.awssdk.services.athena.model.DeleteDataCatalogResponse;
+import software.amazon.awssdk.services.athena.model.GetDataCatalogRequest;
+import software.amazon.awssdk.services.athena.model.GetDataCatalogResponse;
 import software.amazon.awssdk.services.athena.model.InvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -38,6 +42,30 @@ public class DeleteHandlerTest extends BaseHandlerTest {
         when(proxyClient.client().deleteDataCatalog(any(DeleteDataCatalogRequest.class)))
             .thenReturn(DeleteDataCatalogResponse.builder().build());
 
+        final ProgressEvent<ResourceModel, CallbackContext> response = testHandleRequest(request);
+
+        assertSuccessState(response);
+        assertThat(response.getResourceModel()).isNull();
+    }
+
+    @Test
+    public void testFederatedSuccessState() {
+        final ResourceModel model = buildTestResourceModelFederated();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+        // Mock
+        when(proxyClient.client().deleteDataCatalog(any(DeleteDataCatalogRequest.class)))
+                .thenReturn(DeleteDataCatalogResponse.builder().build());
+        when(proxyClient.client().getDataCatalog(any(GetDataCatalogRequest.class)))
+                .thenReturn(
+                        GetDataCatalogResponse.builder()
+                                .dataCatalog(DataCatalog.builder()
+                                        .status(DataCatalogStatus.DELETE_COMPLETE)
+                                        .build())
+                                .build()
+                );
         final ProgressEvent<ResourceModel, CallbackContext> response = testHandleRequest(request);
 
         assertSuccessState(response);

--- a/datacatalog/template.yml
+++ b/datacatalog/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.athena.datacatalog.HandlerWrapper::handleRequest
-      Runtime: java8
-      CodeUri: ./target/aws-athena-datacatalog-handler-1.0-SNAPSHOT.jar
+      Runtime: java11
+      CodeUri: ./target/example-jeff-jeffcatalog-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.athena.datacatalog.HandlerWrapper::testEntrypoint
-      Runtime: java8
-      CodeUri: ./target/aws-athena-datacatalog-handler-1.0-SNAPSHOT.jar
+      Runtime: java11
+      CodeUri: ./target/example-jeff-jeffcatalog-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
PR for visibility. Resource type name will be correctly changed eventually.
*Issue #, if available:*

*Description of changes:*
Adding FEDERATED enum support.
Adding polling for FEDERATED catalogs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
