### PR TITLE
Use managed storage field from the latest aws sdk

### DIFF
--- a/workgroup/aws-athena-workgroup.json
+++ b/workgroup/aws-athena-workgroup.json
@@ -87,13 +87,6 @@
                 "CSE_KMS"
             ]
         },
-        "ManagedQueryResultsTTL": {
-            "description": "The number of days Athena managed storage can keep the query results. Only supporting 1 day for now",
-            "type": "string",
-            "enum": [
-                "1 Day"
-            ]
-        },
         "RemoveBytesScannedCutoffPerQuery": {
             "description": "Indicates that the data usage control limit per query is removed.",
             "type": "boolean"
@@ -243,9 +236,6 @@
                 },
                 "Enabled": {
                     "type": "boolean"
-                },
-                "TimeToLive": {
-                    "$ref": "#/definitions/ManagedQueryResultsTTL"
                 }
             },
             "additionalProperties": false

--- a/workgroup/contract-tests-artifacts/inputs_2.json
+++ b/workgroup/contract-tests-artifacts/inputs_2.json
@@ -1,0 +1,26 @@
+{
+    "CreateInputs": {
+        "Name": "WorkgroupContractTests",
+        "State": "ENABLED",
+        "WorkGroupConfiguration": {
+            "ManagedQueryResultsConfiguration": {
+                "Enabled": true,
+                "EncryptionConfiguration": {
+                    "KmsKey": "{{awsathenaworkgroupcto3}}"
+                }
+            },
+            "EngineVersion": {
+                "SelectedEngineVersion": "AUTO"
+            },
+            "BytesScannedCutoffPerQuery": 100000000
+        },
+        "WorkGroupConfigurationUpdates": {
+            "ManagedQueryResultsConfiguration": {
+                "Enabled": false
+            },
+            "EngineVersion": {
+                "SelectedEngineVersion": "AUTO"
+            }
+        }
+    }
+}

--- a/workgroup/pom.xml
+++ b/workgroup/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>athena</artifactId>
-            <version>2.19.18</version>
+            <version>2.31.55</version>
         </dependency>
         <!-- https://github.com/aws-cloudformation/aws-cloudformation-rpdk-java-plugin/ -->
         <dependency>

--- a/workgroup/src/main/java/software/amazon/athena/workgroup/Translator.java
+++ b/workgroup/src/main/java/software/amazon/athena/workgroup/Translator.java
@@ -2,11 +2,14 @@ package software.amazon.athena.workgroup;
 
 import software.amazon.awssdk.services.athena.model.AclConfiguration;
 import software.amazon.awssdk.services.athena.model.CustomerContentEncryptionConfiguration;
+import software.amazon.awssdk.services.athena.model.ManagedQueryResultsConfiguration;
 import com.google.common.collect.Maps;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import software.amazon.awssdk.services.athena.model.EncryptionConfiguration;
 import software.amazon.awssdk.services.athena.model.EngineVersion;
+import software.amazon.awssdk.services.athena.model.ManagedQueryResultsConfigurationUpdates;
+import software.amazon.awssdk.services.athena.model.ManagedQueryResultsEncryptionConfiguration;
 import software.amazon.awssdk.services.athena.model.ResultConfiguration;
 import software.amazon.awssdk.services.athena.model.ResultConfigurationUpdates;
 import software.amazon.awssdk.services.athena.model.WorkGroupConfiguration;
@@ -58,6 +61,8 @@ class Translator {
             .executionRole(cfnConfiguration.getExecutionRole())
             .customerContentEncryptionConfiguration(cfnConfiguration.getCustomerContentEncryptionConfiguration() != null ?
                     createSdkCustomerContentEncryptionConfigurationFromCfnConfiguration(cfnConfiguration.getCustomerContentEncryptionConfiguration()) : null)
+            .managedQueryResultsConfiguration(cfnConfiguration.getManagedQueryResultsConfiguration() != null ?
+                    createSdkManagedQueryResultsConfigurationFromCfnConfiguration(cfnConfiguration.getManagedQueryResultsConfiguration()) : null)
             .build();
   }
 
@@ -72,6 +77,18 @@ class Translator {
           software.amazon.athena.workgroup.CustomerContentEncryptionConfiguration customerContentEncryptionConfiguration) {
     return CustomerContentEncryptionConfiguration.builder()
             .kmsKey(customerContentEncryptionConfiguration.getKmsKey())
+            .build();
+  }
+
+  private ManagedQueryResultsConfiguration createSdkManagedQueryResultsConfigurationFromCfnConfiguration(
+          software.amazon.athena.workgroup.ManagedQueryResultsConfiguration managedQueryResultsConfiguration) {
+    return ManagedQueryResultsConfiguration.builder()
+            .enabled(managedQueryResultsConfiguration.getEnabled())
+            .encryptionConfiguration(
+                    managedQueryResultsConfiguration.getEncryptionConfiguration() != null ?
+                    ManagedQueryResultsEncryptionConfiguration.builder()
+                    .kmsKey(managedQueryResultsConfiguration.getEncryptionConfiguration().getKmsKey())
+                    .build() : null)
             .build();
   }
 
@@ -113,6 +130,8 @@ class Translator {
             .customerContentEncryptionConfiguration(configuration.getCustomerContentEncryptionConfiguration() != null ?
                     createSdkCustomerContentEncryptionConfigurationFromCfnConfiguration(configuration.getCustomerContentEncryptionConfiguration()) : null)
             .removeCustomerContentEncryptionConfiguration(configuration.getRemoveCustomerContentEncryptionConfiguration())
+            .managedQueryResultsConfigurationUpdates(configuration.getManagedQueryResultsConfiguration() != null ?
+                    createSdkManagedQueryResultsConfigurationUpdatesFromCfnConfiguration(configuration.getManagedQueryResultsConfiguration()) : null)
             .build();
   }
 
@@ -140,6 +159,9 @@ class Translator {
             .requesterPaysEnabled(requestedConfig.getRequesterPaysEnabled() != null ? requestedConfig.getRequesterPaysEnabled() : defaults.requesterPaysEnabled())
             .resultConfigurationUpdates(createSdkResultConfigurationUpdatesFromCfnConfiguration(requestedConfig.getResultConfiguration()))
             .additionalConfiguration(requestedConfig.getAdditionalConfiguration())
+            .managedQueryResultsConfigurationUpdates(requestedConfig.getManagedQueryResultsConfiguration() != null ?
+                    createSdkManagedQueryResultsConfigurationUpdatesFromCfnConfiguration(requestedConfig.getManagedQueryResultsConfiguration()) :
+                    defaults.managedQueryResultsConfigurationUpdates())
             .executionRole(requestedConfig.getExecutionRole());
     if (requestedConfig.getBytesScannedCutoffPerQuery() == null) {
       configUpdates.removeBytesScannedCutoffPerQuery(true);
@@ -175,6 +197,18 @@ class Translator {
     return updatesBuilder.build();
   }
 
+  private ManagedQueryResultsConfigurationUpdates createSdkManagedQueryResultsConfigurationUpdatesFromCfnConfiguration(
+          software.amazon.athena.workgroup.ManagedQueryResultsConfiguration managedQueryResultsConfiguration) {
+    return ManagedQueryResultsConfigurationUpdates.builder()
+            .enabled(managedQueryResultsConfiguration.getEnabled())
+            .encryptionConfiguration(
+                    managedQueryResultsConfiguration.getEncryptionConfiguration() != null ?
+                    ManagedQueryResultsEncryptionConfiguration.builder()
+                    .kmsKey(managedQueryResultsConfiguration.getEncryptionConfiguration().getKmsKey())
+                    .build() : null)
+            .build();
+  }
+
   software.amazon.athena.workgroup.WorkGroupConfiguration createCfnWorkgroupConfigurationFromSdkConfiguration(WorkGroupConfiguration sdkConfiguration) {
     return software.amazon.athena.workgroup.WorkGroupConfiguration.builder()
             .bytesScannedCutoffPerQuery(sdkConfiguration.bytesScannedCutoffPerQuery())
@@ -189,6 +223,8 @@ class Translator {
             .executionRole(sdkConfiguration.executionRole())
             .customerContentEncryptionConfiguration(sdkConfiguration.customerContentEncryptionConfiguration() != null ?
                     createCfnCustomerContentEncryptionConfigurationFromSdkConfiguration(sdkConfiguration.customerContentEncryptionConfiguration()) : null)
+            .managedQueryResultsConfiguration(sdkConfiguration.managedQueryResultsConfiguration() != null ?
+                    createCfnManagedQueryResultsConfigurationFromSdkConfiguration(sdkConfiguration.managedQueryResultsConfiguration()) : null)
             .build();
   }
 
@@ -196,6 +232,17 @@ class Translator {
           CustomerContentEncryptionConfiguration customerContentEncryptionConfiguration) {
     return software.amazon.athena.workgroup.CustomerContentEncryptionConfiguration.builder()
             .kmsKey(customerContentEncryptionConfiguration.kmsKey())
+            .build();
+  }
+
+  private software.amazon.athena.workgroup.ManagedQueryResultsConfiguration createCfnManagedQueryResultsConfigurationFromSdkConfiguration(
+          ManagedQueryResultsConfiguration managedQueryResultsConfiguration) {
+    return software.amazon.athena.workgroup.ManagedQueryResultsConfiguration.builder()
+            .enabled(managedQueryResultsConfiguration.enabled())
+            .encryptionConfiguration(managedQueryResultsConfiguration.encryptionConfiguration() != null ?
+                    ManagedStorageEncryptionConfiguration.builder()
+                                    .kmsKey(managedQueryResultsConfiguration.encryptionConfiguration().kmsKey())
+                                    .build() : null)
             .build();
   }
 

--- a/workgroup/src/test/java/software/amazon/athena/workgroup/TranslatorTest.java
+++ b/workgroup/src/test/java/software/amazon/athena/workgroup/TranslatorTest.java
@@ -107,6 +107,39 @@ public class TranslatorTest {
   }
 
   @Test
+  void testCreateSdkWorkgroupConfigurationFromCfnConfigurationForManagedStorageWorkgroup() {
+    software.amazon.athena.workgroup.EngineVersion sqlConfiguration = software.amazon.athena.workgroup.EngineVersion.builder()
+            .selectedEngineVersion("AUTO")
+            .effectiveEngineVersion("Athena engine version 2")
+            .build();
+    software.amazon.athena.workgroup.WorkGroupConfiguration cfnWorkGroupConfiguration =
+            getBareMinCfnWorkGroupConfiguration()
+                    .bytesScannedCutoffPerQuery(10_000_000_000L)
+                    .engineVersion(sqlConfiguration)
+                    .managedQueryResultsConfiguration(ManagedQueryResultsConfiguration.builder()
+                            .enabled(true)
+                            .encryptionConfiguration(ManagedStorageEncryptionConfiguration.builder()
+                                    .kmsKey("TestKey")
+                                    .build())
+                            .build())
+                    .build();
+    WorkGroupConfiguration sdkWorkGroupConfiguration =
+            new Translator().createSdkWorkgroupConfigurationFromCfnConfiguration(cfnWorkGroupConfiguration);
+    assertThat(cfnWorkGroupConfiguration.getEnforceWorkGroupConfiguration()).isEqualTo(sdkWorkGroupConfiguration.enforceWorkGroupConfiguration());
+    assertThat(cfnWorkGroupConfiguration.getPublishCloudWatchMetricsEnabled()).isEqualTo(sdkWorkGroupConfiguration.publishCloudWatchMetricsEnabled());
+    assertThat(cfnWorkGroupConfiguration.getRequesterPaysEnabled()).isEqualTo(sdkWorkGroupConfiguration.requesterPaysEnabled());
+    assertThat(cfnWorkGroupConfiguration.getEngineVersion().getSelectedEngineVersion())
+            .isEqualTo(sdkWorkGroupConfiguration.engineVersion().selectedEngineVersion());
+    assertThat(cfnWorkGroupConfiguration.getEngineVersion().getEffectiveEngineVersion())
+            .isEqualTo(sdkWorkGroupConfiguration.engineVersion().effectiveEngineVersion());
+    assertThat(cfnWorkGroupConfiguration.getExecutionRole()).isEqualTo(sdkWorkGroupConfiguration.executionRole());
+    assertThat(cfnWorkGroupConfiguration.getManagedQueryResultsConfiguration().getEnabled())
+            .isEqualTo(sdkWorkGroupConfiguration.managedQueryResultsConfiguration().enabled());
+    assertThat(cfnWorkGroupConfiguration.getManagedQueryResultsConfiguration().getEncryptionConfiguration().getKmsKey())
+            .isEqualTo(sdkWorkGroupConfiguration.managedQueryResultsConfiguration().encryptionConfiguration().kmsKey());
+  }
+
+  @Test
   void testCreateSdkWorkgroupConfigurationFromCfnConfigurationWithResultConfigurationNullable() {
     software.amazon.athena.workgroup.WorkGroupConfiguration cfnWorkGroupConfiguration = software.amazon.athena.workgroup.WorkGroupConfiguration.builder()
             .enforceWorkGroupConfiguration(true)
@@ -188,6 +221,32 @@ public class TranslatorTest {
             .isEqualTo(sdkWorkGroupConfigurationUpdates.customerContentEncryptionConfiguration().kmsKey());
     assertThat(cfnWorkGroupConfiguration.getRemoveCustomerContentEncryptionConfiguration())
             .isEqualTo(sdkWorkGroupConfigurationUpdates.removeCustomerContentEncryptionConfiguration());
+  }
+
+  @Test
+  void testCreateSdkConfigurationUpdatesFromCfnConfigurationUpdatesForManagedStorageWorkgroup() {
+    software.amazon.athena.workgroup.EngineVersion engineVersion = software.amazon.athena.workgroup.EngineVersion.builder()
+            .selectedEngineVersion("AUTO")
+            .effectiveEngineVersion("Athena engine version 2")
+            .build();
+    software.amazon.athena.workgroup.WorkGroupConfigurationUpdates cfnWorkGroupConfiguration =
+            software.amazon.athena.workgroup.WorkGroupConfigurationUpdates.builder()
+                    .bytesScannedCutoffPerQuery(10_000_000_000L)
+                    .managedQueryResultsConfiguration(ManagedQueryResultsConfiguration.builder()
+                            .enabled(true)
+                            .encryptionConfiguration(ManagedStorageEncryptionConfiguration.builder()
+                                    .kmsKey("testKey")
+                                    .build())
+                            .build())
+                    .engineVersion(engineVersion)
+                    .removeCustomerContentEncryptionConfiguration(true)
+                    .build();
+    WorkGroupConfigurationUpdates sdkWorkGroupConfigurationUpdates =
+            new Translator().createSdkConfigurationUpdatesFromCfnConfigurationUpdates(cfnWorkGroupConfiguration);
+    assertThat(cfnWorkGroupConfiguration.getManagedQueryResultsConfiguration().getEnabled())
+            .isEqualTo(sdkWorkGroupConfigurationUpdates.managedQueryResultsConfigurationUpdates().enabled());
+    assertThat(cfnWorkGroupConfiguration.getManagedQueryResultsConfiguration().getEncryptionConfiguration().getKmsKey())
+            .isEqualTo(sdkWorkGroupConfigurationUpdates.managedQueryResultsConfigurationUpdates().encryptionConfiguration().kmsKey());
   }
 
   @Test

--- a/workgroup/src/test/java/software/amazon/athena/workgroup/UpdateHandlerTest.java
+++ b/workgroup/src/test/java/software/amazon/athena/workgroup/UpdateHandlerTest.java
@@ -652,8 +652,8 @@ public class UpdateHandlerTest {
   void testSuccessStateWithManagedStorageUpdates() {
     // Prepare inputs
     final ResourceModel resourceModel = ResourceModel.builder()
-            .name("Primary")
-            .description("Primary workgroup update description")
+            .name("ManagedStorage")
+            .description("Test managed storage description")
             .workGroupConfigurationUpdates(WorkGroupConfigurationUpdates.builder()
                     .enforceWorkGroupConfiguration(true)
                     .bytesScannedCutoffPerQuery(10_000_000_000L)
@@ -664,13 +664,11 @@ public class UpdateHandlerTest {
                             .encryptionConfiguration(ManagedStorageEncryptionConfiguration.builder()
                                     .kmsKey("eiifcckijivunlgvvggjeiheertfetujenrnndugggnh")
                                     .build())
-                            .timeToLive("1 Day")
                             .build())
                     .build())
-            .state("disabled")
             .build();
     final ResourceModel oldModel = ResourceModel.builder()
-            .name("Primary")
+            .name("ManagedStorage")
             .build();
 
     final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change will use the newly added field for managed storage to update the CFN template. Already locally passed the contract tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
